### PR TITLE
[api] Add blog JSON flow management

### DIFF
--- a/src/controllers/blog-controller.ts
+++ b/src/controllers/blog-controller.ts
@@ -1,0 +1,60 @@
+import { BlogService } from '@app/services';
+import { Controller, Get, Post, Inject } from '@lib/decorators';
+import type { Request, Response } from 'express';
+import multer from 'multer';
+
+const upload = multer();
+
+@Controller('/api/blog')
+export default class BlogController {
+  @Inject() private _blogService: BlogService;
+
+  @Get('/:flow')
+  public getFlow(req: Request, res: Response) {
+    const { flow } = req.params;
+    const data = this._blogService.getFlow(flow);
+    if (!data) {
+      return res.status(404).json({ message: `Flow ${flow} not found` });
+    }
+    res.status(200).json({ flux: flow, entries: data.entries });
+  }
+
+  @Post('/flows')
+  public createFlow(req: Request, res: Response) {
+    const { name, keys = [] } = req.body;
+    try {
+      this._blogService.createFlow(name, Array.isArray(keys) ? keys : []);
+      res.status(201).json({ message: 'created' });
+    } catch (e: any) {
+      res.status(400).json({ message: e.message });
+    }
+  }
+
+  @Post('/:flow')
+  public addEntry(req: Request, res: Response) {
+    const { flow } = req.params;
+    try {
+      this._blogService.addEntry(flow, req.body);
+      res.status(201).json({ message: 'created' });
+    } catch (e: any) {
+      res.status(400).json({ message: e.message });
+    }
+  }
+
+  @Post('/:flow/upload')
+  public uploadJson(req: Request, res: Response) {
+    const { flow } = req.params;
+    upload.single('file')(req, res, (err: any) => {
+      if (err) return res.status(400).json({ message: err.message });
+      try {
+        const raw = req.file?.buffer.toString() ?? '[]';
+        const entries = JSON.parse(raw);
+        if (!Array.isArray(entries)) throw new Error('Invalid JSON');
+        entries.forEach((entry) => this._blogService.addEntry(flow, entry));
+        res.status(201).json({ message: 'uploaded', count: entries.length });
+      } catch (e: any) {
+        res.status(400).json({ message: e.message });
+      }
+    });
+  }
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -3,3 +3,4 @@ export { default as IndexController } from './index-controller';
 export { default as ThemeParksController } from './theme-parks-controller';
 export { default as ScrapeController } from './scrape-controller';
 export { default as CookieController } from './cookie-controller';
+export { default as BlogController } from './blog-controller';

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
   ThemeParksController,
   ScrapeController,
   CookieController,
+  BlogController,
 } from '@app/controllers';
 
 class Application {
@@ -20,6 +21,7 @@ class Application {
       ThemeParksController,
       ScrapeController,
       CookieController,
+      BlogController,
     ]);
 
   }

--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -1,0 +1,38 @@
+import { Service } from '@lib/decorators';
+import type { BlogFlow, BlogEntry } from '@app/types/blog';
+
+interface Flows {
+  [name: string]: BlogFlow;
+}
+
+@Service()
+export default class BlogService {
+  private _flows: Flows = {};
+
+  public createFlow(name: string, keys: string[]) {
+    if (this._flows[name]) {
+      throw new Error(`Flow ${name} already exists`);
+    }
+    this._flows[name] = { keys, entries: [] };
+  }
+
+  public getFlow(name: string) {
+    return this._flows[name];
+  }
+
+  public addEntry(flowName: string, entry: BlogEntry) {
+    const flow = this._flows[flowName];
+    if (!flow) throw new Error(`Flow ${flowName} not found`);
+
+    const entryKeys = Object.keys(entry);
+    const hasSameKeys =
+      flow.keys.every((k: string) => entryKeys.includes(k)) &&
+      entryKeys.every((k: string) => flow.keys.includes(k));
+
+    if (!hasSameKeys) {
+      throw new Error('Invalid entry keys');
+    }
+
+    flow.entries.push(entry);
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
 export { default as RollerCoasterService } from './roller-coaster-service';
 export { default as ThemeParkService } from './theme-park-service';
 export { default as ScrapeService } from './scrape-service';
+export { default as BlogService } from './blog-service';

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,8 @@
+export interface BlogEntry {
+  [key: string]: any;
+}
+
+export interface BlogFlow {
+  keys: string[];
+  entries: BlogEntry[];
+}

--- a/static/blog/index.html
+++ b/static/blog/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Blog admin</title>
+</head>
+<body>
+  <h1>Blog configuration</h1>
+  <section>
+    <h2>Create flow</h2>
+    <form id="flow-form">
+      <input name="name" placeholder="flow name" required />
+      <input name="keys" placeholder="keys (comma separated)" />
+      <button type="submit">Create</button>
+    </form>
+  </section>
+  <section>
+    <h2>Add entry</h2>
+    <form id="entry-form">
+      <input name="flow" placeholder="flow" required />
+      <textarea name="payload" placeholder='{"title":".."}' required></textarea>
+      <button type="submit">Add</button>
+    </form>
+  </section>
+  <section>
+    <h2>Upload JSON</h2>
+    <form id="upload-form" enctype="multipart/form-data">
+      <input name="flow" placeholder="flow" required />
+      <input type="file" name="file" accept="application/json" required />
+      <button type="submit">Upload</button>
+    </form>
+  </section>
+<script>
+const flowForm = document.getElementById('flow-form');
+flowForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const name = flowForm.name.value;
+  const keys = flowForm.keys.value.split(',').map(k => k.trim()).filter(Boolean);
+  await fetch('/api/blog/flows', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name, keys }) });
+  alert('flow created');
+});
+
+const entryForm = document.getElementById('entry-form');
+entryForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const flow = entryForm.flow.value;
+  const payload = JSON.parse(entryForm.payload.value);
+  await fetch('/api/blog/' + flow, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+  alert('entry added');
+});
+
+const uploadForm = document.getElementById('upload-form');
+uploadForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const flow = uploadForm.flow.value;
+  const fd = new FormData(uploadForm);
+  await fetch('/api/blog/' + flow + '/upload', { method: 'POST', body: fd });
+  alert('uploaded');
+});
+</script>
+</body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
       "@app/constants": ["constants"],
       "@app/db": ["db"],
       "@app/types": ["types"],
+      "@app/types/*": ["types/*"],
       "@scraping": ["scraping"],
       "@scraping/*": ["scraping/*"],
       "@config": ["config"]


### PR DESCRIPTION
## Summary
- add BlogService to handle dynamic JSON flows
- expose API for creating flows, adding entries, and JSON upload via BlogController
- serve basic admin interface at `/blog`

## Testing
- `pnpm build`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1438bc70833187733367aa9a97c1