### PR TITLE
[ridexplorers_api] Add JSON blog flow management

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "scrape": "ts-node -r tsconfig-paths/register ./src/scraping/main.ts && npm run scrape:map-coaster-photos",
     "scrape:theme-parks": "ts-node -r tsconfig-paths/register ./src/scraping/scrape-theme-parks",
     "scrape:map-coaster-photos": "ts-node -r tsconfig-paths/register ./src/scraping/map-coaster-photos.ts",
-    "scrape:random": "ts-node -r tsconfig-paths/register ./src/scraping/scrape-random-coasters.ts"
+    "scrape:random": "ts-node -r tsconfig-paths/register ./src/scraping/scrape-random-coasters.ts",
+    "test": "node --test --require reflect-metadata --require tsconfig-paths/register --require ts-node/register test/blog-service.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -4,3 +4,5 @@ export const __PHOTOS_BY_COASTER_DB_FILENAME__: string = 'photos-by-coaster';
 export const __PROCESSED_COASTERS_PHOTOS_DB_FILENAME__: string = 'processed-coasters-photos';
 export const __THEME_PARKS_DB_FILENAME__: string = 'theme-parks';
 export const __RANDOM_COASTERS_DB_FILENAME__: string = 'random-coasters';
+export const __BLOG_FLOWS_DB_FILENAME__: string = 'blog_flows';
+export const __BLOG_ENTRIES_DB_FILENAME__: string = 'blog_entries';

--- a/src/controllers/blog-controller.ts
+++ b/src/controllers/blog-controller.ts
@@ -1,5 +1,5 @@
 import { BlogService } from '@app/services';
-import { Controller, Get, Post, Inject } from '@lib/decorators';
+import { Controller, Get, Post, Patch, Delete, Inject } from '@lib/decorators';
 import type { Request, Response } from 'express';
 import multer from 'multer';
 
@@ -9,48 +9,108 @@ const upload = multer();
 export default class BlogController {
   @Inject() private _blogService: BlogService;
 
-  @Get('/:flow')
-  public getFlow(req: Request, res: Response) {
-    const { flow } = req.params;
-    const data = this._blogService.getFlow(flow);
-    if (!data) {
-      return res.status(404).json({ message: `Flow ${flow} not found` });
-    }
-    res.status(200).json({ flux: flow, entries: data.entries });
+  @Get('/flows')
+  public async listFlows(req: Request, res: Response) {
+    const { q, page, limit } = req.query;
+    const data = await this._blogService.listFlows({
+      q: q as string,
+      page: page ? Number(page) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
+    res.status(200).json(data);
   }
 
   @Post('/flows')
-  public createFlow(req: Request, res: Response) {
-    const { name, keys = [] } = req.body;
+  public async createFlow(req: Request, res: Response) {
+    const { name, slug, schema = {} } = req.body;
     try {
-      this._blogService.createFlow(name, Array.isArray(keys) ? keys : []);
+      const flow = await this._blogService.createFlow(name, slug, schema);
+      res.status(201).json(flow);
+    } catch (e: any) {
+      res.status(400).json({ message: e.message });
+    }
+  }
+
+  @Patch('/flows/:slug')
+  public async rename(req: Request, res: Response) {
+    const { slug } = req.params;
+    const { name, newSlug } = req.body;
+    try {
+      const flow = await this._blogService.renameFlow(slug, name, newSlug);
+      res.status(200).json({ ...flow, jsonUrl: `/api/blog/${flow.slug}`, message: 'Flow renamed successfully.' });
+    } catch (e: any) {
+      res.status(400).json({ message: e.message });
+    }
+  }
+
+  @Post('/flows/:slug/duplicate')
+  public async duplicate(req: Request, res: Response) {
+    const { slug } = req.params;
+    const { newName, newSlug, withEntries = false } = req.body;
+    try {
+      const flow = await this._blogService.duplicateFlow(slug, newName, newSlug, withEntries);
+      res.status(201).json({
+        ...flow,
+        copiedSchema: true,
+        copiedEntries: withEntries,
+        jsonUrl: `/api/blog/${flow.slug}`,
+        message: 'Flow duplicated successfully.',
+      });
+    } catch (e: any) {
+      res.status(400).json({ message: e.message });
+    }
+  }
+
+  @Delete('/flows/:slug')
+  public async remove(req: Request, res: Response) {
+    const { slug } = req.params;
+    try {
+      await this._blogService.deleteFlow(slug);
+      res.status(200).json({ message: 'Flow deleted.' });
+    } catch (e: any) {
+      res.status(400).json({ message: e.message });
+    }
+  }
+
+  @Get('/:slug')
+  public async getEntries(req: Request, res: Response) {
+    const { slug } = req.params;
+    const { page, limit, sort, since, until } = req.query;
+    try {
+      const data = await this._blogService.getEntries(slug, {
+        page: page ? Number(page) : undefined,
+        limit: limit ? Number(limit) : undefined,
+        sort: sort === 'asc' ? 'asc' : 'desc',
+        since: since as string | undefined,
+        until: until as string | undefined,
+      });
+      res.status(200).json(data);
+    } catch (e: any) {
+      res.status(404).json({ message: e.message });
+    }
+  }
+
+  @Post('/:slug')
+  public async addEntry(req: Request, res: Response) {
+    const { slug } = req.params;
+    try {
+      await this._blogService.addEntry(slug, req.body);
       res.status(201).json({ message: 'created' });
     } catch (e: any) {
       res.status(400).json({ message: e.message });
     }
   }
 
-  @Post('/:flow')
-  public addEntry(req: Request, res: Response) {
-    const { flow } = req.params;
-    try {
-      this._blogService.addEntry(flow, req.body);
-      res.status(201).json({ message: 'created' });
-    } catch (e: any) {
-      res.status(400).json({ message: e.message });
-    }
-  }
-
-  @Post('/:flow/upload')
+  @Post('/:slug/upload')
   public uploadJson(req: Request, res: Response) {
-    const { flow } = req.params;
+    const { slug } = req.params;
     upload.single('file')(req, res, (err: any) => {
       if (err) return res.status(400).json({ message: err.message });
       try {
         const raw = req.file?.buffer.toString() ?? '[]';
         const entries = JSON.parse(raw);
         if (!Array.isArray(entries)) throw new Error('Invalid JSON');
-        entries.forEach((entry) => this._blogService.addEntry(flow, entry));
+        entries.forEach((entry) => this._blogService.addEntry(slug, entry));
         res.status(201).json({ message: 'uploaded', count: entries.length });
       } catch (e: any) {
         res.status(400).json({ message: e.message });

--- a/src/lib/decorators/controller-decorator.ts
+++ b/src/lib/decorators/controller-decorator.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { MetadataKeys } from '@lib/types';
 
 export default function Controller(basePath: string = '/'): ClassDecorator {

--- a/src/lib/decorators/index.ts
+++ b/src/lib/decorators/index.ts
@@ -3,6 +3,7 @@ export { default as Controller } from './controller-decorator';
 export { default as methodDecoratorFactory } from './method-decorator-factory';
 export { default as Get } from './get-decorator';
 export { default as Post } from './post-decorator';
+export { default as Patch } from './patch-decorator';
 export { default as Delete } from './delete-decorator';
 export { default as LogRequest } from './log-request-decorator';
 export { default as Service } from './service-decorator';

--- a/src/lib/decorators/inject-decorator.ts
+++ b/src/lib/decorators/inject-decorator.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';
+
 export default function Inject(): PropertyDecorator {
   return function (target, propertyKey) {
     const containerClass = target.constructor;

--- a/src/lib/decorators/method-decorator-factory.ts
+++ b/src/lib/decorators/method-decorator-factory.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { MetadataKeys } from '@lib/types';
 import type { Methods, Route } from '@lib/types';
 

--- a/src/lib/decorators/patch-decorator.ts
+++ b/src/lib/decorators/patch-decorator.ts
@@ -1,0 +1,4 @@
+import { methodDecoratorFactory } from '@lib/decorators';
+import { Methods } from '@lib/types';
+
+export default methodDecoratorFactory(Methods.PATCH);

--- a/src/lib/decorators/service-decorator.ts
+++ b/src/lib/decorators/service-decorator.ts
@@ -1,4 +1,4 @@
-import { DiContainer } from '@lib/core';
+import DiContainer from '@lib/core/di-container';
 
 export default function Service(): Function {
   return (target: { new (): any }): void => {   

--- a/src/lib/types/methods.ts
+++ b/src/lib/types/methods.ts
@@ -2,5 +2,6 @@ export enum Methods {
   GET = 'get',
   POST = 'post',
   PUT = 'put',
+  PATCH = 'patch',
   DELETE = 'delete',
 }

--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -1,38 +1,149 @@
 import { Service } from '@lib/decorators';
+import JsonDB from '@app/db';
+import { __BLOG_FLOWS_DB_FILENAME__, __BLOG_ENTRIES_DB_FILENAME__ } from '@app/constants';
 import type { BlogFlow, BlogEntry } from '@app/types/blog';
 
-interface Flows {
-  [name: string]: BlogFlow;
+interface ListOptions {
+  q?: string;
+  page?: number;
+  limit?: number;
+}
+
+interface EntryQuery {
+  page?: number;
+  limit?: number;
+  sort?: 'asc' | 'desc';
+  since?: string;
+  until?: string;
 }
 
 @Service()
 export default class BlogService {
-  private _flows: Flows = {};
+  private _db: JsonDB;
 
-  public createFlow(name: string, keys: string[]) {
-    if (this._flows[name]) {
-      throw new Error(`Flow ${name} already exists`);
+  constructor() {
+    this._db = JsonDB.getInstance();
+    this._db.createDBFile(__BLOG_FLOWS_DB_FILENAME__, []);
+    this._db.createDBFile(__BLOG_ENTRIES_DB_FILENAME__, []);
+  }
+
+  private _now(): string {
+    return new Date().toISOString();
+  }
+
+  private async _getFlows(): Promise<BlogFlow[]> {
+    return await this._db.readDBFile<BlogFlow[]>(__BLOG_FLOWS_DB_FILENAME__);
+  }
+
+  private async _getEntries(): Promise<BlogEntry[]> {
+    return await this._db.readDBFile<BlogEntry[]>(__BLOG_ENTRIES_DB_FILENAME__);
+  }
+
+  public async listFlows({ q = '', page = 1, limit = 25 }: ListOptions) {
+    const flows = (await this._getFlows()).filter((f) => !f.deletedAt);
+    const entries = await this._getEntries();
+    let items = flows.map((flow) => ({
+      name: flow.name,
+      slug: flow.slug,
+      entriesCount: entries.filter((e) => e.flowId === flow.id).length,
+      updatedAt: flow.updatedAt,
+      jsonUrl: `/api/blog/${flow.slug}`,
+    }));
+    if (q) {
+      const lower = q.toLowerCase();
+      items = items.filter((f) => f.name.toLowerCase().includes(lower) || f.slug.toLowerCase().includes(lower));
     }
-    this._flows[name] = { keys, entries: [] };
+    const total = items.length;
+    const start = (page - 1) * limit;
+    const paginated = items.slice(start, start + limit);
+    return { items: paginated, page, limit, total };
   }
 
-  public getFlow(name: string) {
-    return this._flows[name];
+  public async createFlow(name: string, slug: string, schema: { [key: string]: string }): Promise<BlogFlow> {
+    const flows = await this._getFlows();
+    if (flows.some((f) => f.slug === slug && !f.deletedAt)) {
+      throw new Error('Flow already exists');
+    }
+    const now = this._now();
+    const flow: BlogFlow = { id: Date.now(), name, slug, schema, createdAt: now, updatedAt: now };
+    flows.push(flow);
+    await this._db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, flows);
+    return flow;
   }
 
-  public addEntry(flowName: string, entry: BlogEntry) {
-    const flow = this._flows[flowName];
-    if (!flow) throw new Error(`Flow ${flowName} not found`);
+  public async renameFlow(slug: string, newName: string, newSlug: string): Promise<BlogFlow> {
+    const flows = await this._getFlows();
+    const flow = flows.find((f) => f.slug === slug && !f.deletedAt);
+    if (!flow) throw new Error('Flow not found');
+    if (newSlug !== slug && flows.some((f) => f.slug === newSlug && !f.deletedAt)) {
+      throw new Error('Slug already exists');
+    }
+    flow.name = newName;
+    flow.slug = newSlug;
+    flow.updatedAt = this._now();
+    await this._db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, flows);
+    return flow;
+  }
 
-    const entryKeys = Object.keys(entry);
+  public async duplicateFlow(slug: string, newName: string, newSlug: string, withEntries: boolean): Promise<BlogFlow> {
+    const flows = await this._getFlows();
+    const original = flows.find((f) => f.slug === slug && !f.deletedAt);
+    if (!original) throw new Error('Flow not found');
+    if (flows.some((f) => f.slug === newSlug && !f.deletedAt)) throw new Error('Slug already exists');
+    const now = this._now();
+    const copy: BlogFlow = { id: Date.now(), name: newName, slug: newSlug, schema: { ...original.schema }, createdAt: now, updatedAt: now };
+    flows.push(copy);
+    await this._db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, flows);
+    if (withEntries) {
+      const entries = await this._getEntries();
+      const newEntries = entries
+        .filter((e) => e.flowId === original.id)
+        .map((e) => ({ id: Date.now() + Math.random(), flowId: copy.id, payload: e.payload, createdAt: now, updatedAt: now }));
+      await this._db.writeDBFile(__BLOG_ENTRIES_DB_FILENAME__, [...entries, ...newEntries]);
+    }
+    return copy;
+  }
+
+  public async deleteFlow(slug: string): Promise<void> {
+    const flows = await this._getFlows();
+    const flow = flows.find((f) => f.slug === slug && !f.deletedAt);
+    if (!flow) throw new Error('Flow not found');
+    flow.deletedAt = this._now();
+    await this._db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, flows);
+  }
+
+  public async addEntry(slug: string, payload: { [key: string]: any }) {
+    const flows = await this._getFlows();
+    const flow = flows.find((f) => f.slug === slug && !f.deletedAt);
+    if (!flow) throw new Error(`Flow ${slug} not found`);
+    const entryKeys = Object.keys(payload);
     const hasSameKeys =
-      flow.keys.every((k: string) => entryKeys.includes(k)) &&
-      entryKeys.every((k: string) => flow.keys.includes(k));
+      Object.keys(flow.schema).every((k) => entryKeys.includes(k)) &&
+      entryKeys.every((k) => Object.keys(flow.schema).includes(k));
+    if (!hasSameKeys) throw new Error('Invalid entry keys');
+    const entries = await this._getEntries();
+    const now = this._now();
+    entries.push({ id: Date.now(), flowId: flow.id, payload, createdAt: now, updatedAt: now });
+    flow.updatedAt = now;
+    await this._db.writeDBFile(__BLOG_ENTRIES_DB_FILENAME__, entries);
+    await this._db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, flows);
+  }
 
-    if (!hasSameKeys) {
-      throw new Error('Invalid entry keys');
-    }
-
-    flow.entries.push(entry);
+  public async getEntries(slug: string, { page = 1, limit = 25, sort = 'desc', since, until }: EntryQuery) {
+    const flows = await this._getFlows();
+    const flow = flows.find((f) => f.slug === slug && !f.deletedAt);
+    if (!flow) throw new Error('Flow not found');
+    let items = (await this._getEntries()).filter((e) => e.flowId === flow.id);
+    if (since) items = items.filter((e) => e.createdAt >= since);
+    if (until) items = items.filter((e) => e.createdAt <= until);
+    items.sort((a, b) =>
+      sort === 'asc'
+        ? a.createdAt.localeCompare(b.createdAt)
+        : b.createdAt.localeCompare(a.createdAt)
+    );
+    const total = items.length;
+    const start = (page - 1) * limit;
+    const paginated = items.slice(start, start + limit);
+    return { items: paginated, page, limit, total };
   }
 }

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,8 +1,17 @@
-export interface BlogEntry {
-  [key: string]: any;
+export interface BlogFlow {
+  id: number;
+  name: string;
+  slug: string;
+  schema: { [key: string]: string };
+  createdAt: string;
+  updatedAt: string;
+  deletedAt?: string | null;
 }
 
-export interface BlogFlow {
-  keys: string[];
-  entries: BlogEntry[];
+export interface BlogEntry {
+  id: number;
+  flowId: number;
+  payload: { [key: string]: any };
+  createdAt: string;
+  updatedAt: string;
 }

--- a/test/blog-service.test.ts
+++ b/test/blog-service.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import BlogService from '../src/services/blog-service';
+import JsonDB from '../src/db';
+import { __BLOG_FLOWS_DB_FILENAME__, __BLOG_ENTRIES_DB_FILENAME__ } from '../src/constants/database';
+
+const db = JsonDB.getInstance();
+
+async function resetDB() {
+  await db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, []);
+  await db.writeDBFile(__BLOG_ENTRIES_DB_FILENAME__, []);
+}
+
+test('create, duplicate, rename and delete flow', async () => {
+  await resetDB();
+  const service = new BlogService();
+  await service.createFlow('News Parks', 'news-parks', { title: 'string' });
+  await service.addEntry('news-parks', { title: 'A' });
+
+  // duplicate with entries
+  await service.duplicateFlow('news-parks', 'News Parks Copy', 'news-parks-copy', true);
+  const list = await service.listFlows({});
+  assert.equal(list.total, 2);
+
+  // rename
+  await service.renameFlow('news-parks', 'Parks Updates', 'parks-updates');
+  const renamed = await service.listFlows({ q: 'parks-updates' });
+  assert.equal(renamed.items[0].name, 'Parks Updates');
+
+  // delete
+  await service.deleteFlow('parks-updates');
+  const afterDelete = await service.listFlows({});
+  assert.equal(afterDelete.total, 1);
+});


### PR DESCRIPTION
## Summary
- support listing, renaming, duplicating and deleting blog flows with JSON persistence
- expose REST endpoints for flow management and entry retrieval
- cover blog flow lifecycle with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1bae57dc833191258c0438181467