### PR TITLE
[express-server-ts] Validate slug before deleting blog flow

### DIFF
--- a/static/blog/index.html
+++ b/static/blog/index.html
@@ -224,9 +224,14 @@ async function loadFlows() {
 
       const deleteBtn = tr.querySelector('.delete-btn');
       deleteBtn.addEventListener('click', async () => {
+        const slug = flow.slug;
+        if (!slug) {
+          alert('Missing slug');
+          return;
+        }
         if (!confirm(`Delete flow "${flow.name}"?`)) return;
         try {
-          const res = await fetch(`/api/blog/flows/${flow.slug}`, { method: 'DELETE' });
+          const res = await fetch(`/api/blog/flows/${slug}`, { method: 'DELETE' });
           if (!res.ok) throw new Error('Request failed');
           await loadFlows();
         } catch (e) {


### PR DESCRIPTION
## Summary
- ensure deletion logic verifies slug exists before issuing delete request

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb2738624833193a1bca87eb5c8ea