### PR TITLE
[ridexplorers_api] Handle missing slug in blog flow listing

### DIFF
--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -51,7 +51,11 @@ export default class BlogService {
     }));
     if (q) {
       const lower = q.toLowerCase();
-      items = items.filter((f) => f.name.toLowerCase().includes(lower) || f.slug.toLowerCase().includes(lower));
+      items = items.filter(
+        (f) =>
+          (f.name && f.name.toLowerCase().includes(lower)) ||
+          (f.slug && f.slug.toLowerCase().includes(lower))
+      );
     }
     const total = items.length;
     const start = (page - 1) * limit;

--- a/test/blog-service.test.ts
+++ b/test/blog-service.test.ts
@@ -32,3 +32,15 @@ test('create, duplicate, rename and delete flow', async () => {
   const afterDelete = await service.listFlows({});
   assert.equal(afterDelete.total, 1);
 });
+
+test('listFlows handles flows missing slug or name', async () => {
+  await resetDB();
+  const now = new Date().toISOString();
+  await db.writeDBFile(__BLOG_FLOWS_DB_FILENAME__, [
+    { id: 1, name: 'Valid', slug: 'valid', schema: {}, createdAt: now, updatedAt: now },
+    { id: 2, name: 'Broken', schema: {}, createdAt: now, updatedAt: now } as any,
+  ]);
+  const service = new BlogService();
+  const list = await service.listFlows({ q: 'something' });
+  assert.equal(list.total, 0);
+});


### PR DESCRIPTION
## Summary
- avoid accessing `toLowerCase` on undefined flow properties
- test listFlows with malformed data

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec526c21083319d1461805b5df4f1