### PR TITLE
[express-server-ts] Handle blog entry form errors

### DIFF
--- a/static/blog/index.html
+++ b/static/blog/index.html
@@ -110,11 +110,20 @@ entryForm.addEventListener('submit', async (e) => {
     alert('Invalid JSON');
     return;
   }
-  await fetch('/api/blog/' + flow, {
+  const res = await fetch('/api/blog/' + flow, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
+  if (!res.ok) {
+    let errMsg = 'Failed to add entry';
+    try {
+      const data = await res.json();
+      errMsg = data.error || data.message || errMsg;
+    } catch {}
+    showToast(errMsg);
+    return;
+  }
   showToast('entry added');
   entryForm.reset();
   payloadEditor.set({});


### PR DESCRIPTION
## Summary
- check API response when adding blog entries
- show error toast with server message when request fails

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed48b35dc8331a2994e3fed6c2729