### PR TITLE
[api] Update docs and code comments

### DIFF
--- a/GUIDE_DEBUTANT.md
+++ b/GUIDE_DEBUTANT.md
@@ -6,6 +6,7 @@ Ce guide décrit, étape par étape, comment installer et exécuter **RIDEXPLORE
 
 - **Node.js 18** ou version supérieure. Téléchargez l'installateur depuis [nodejs.org](https://nodejs.org/) et installez-le comme n'importe quel programme.
 - **Git** pour récupérer le code du projet. Sur Windows vous pouvez installer [Git for Windows](https://git-scm.com/download/win). Sur macOS ou Linux, `git` est généralement disponible via le gestionnaire de paquets (`brew`, `apt`, `dnf`, ...).
+- **pnpm** pour gérer les dépendances (`npm install -g pnpm` si besoin).
 
 Vérifiez que les outils sont bien installés :
 
@@ -31,7 +32,7 @@ La dernière ligne vous place dans le dossier du projet. Toutes les commandes su
 Toutes les bibliothèques nécessaires sont listées dans `package.json`. Installez-les avec :
 
 ```bash
-npm install   # télécharge toutes les dépendances
+pnpm install   # télécharge toutes les dépendances
 ```
 
 Cette étape peut prendre quelques minutes.
@@ -60,7 +61,7 @@ Vous pouvez modifier les valeurs selon vos besoins. Si vous ne créez pas ce fic
 Avant de lancer le serveur en production, compilez le code TypeScript vers JavaScript :
 
 ```bash
-npm run build   # génère les fichiers dans le dossier dist/
+pnpm run build   # génère les fichiers dans le dossier dist/
 ```
 
 Cette commande crée un dossier `dist/` contenant le JavaScript prêt pour la production.
@@ -70,13 +71,13 @@ Cette commande crée un dossier `dist/` contenant le JavaScript prêt pour la pr
 - **Mode développement** (recharge automatique à chaque modification) :
 
 ```bash
-npm run start:dev
+pnpm run start:dev
 ```
 
 - **Mode production** (exécute la version compilée) :
 
 ```bash
-npm run start:prod
+pnpm run start:prod
 ```
 
 Par défaut, l'API écoute sur le port `8000`. Une fois démarrée, ouvrez [http://localhost:8000/docs](http://localhost:8000/docs) pour accéder à la documentation interactive.
@@ -99,9 +100,9 @@ Le projet permet de récupérer les données depuis RCDB. Les scripts peuvent ê
 - Depuis le terminal :
 
 ```bash
-npm run scrape           # récupère les montagnes russes
-npm run scrape:theme-parks # récupère les parcs d'attractions
-npm run scrape:random # récupère un échantillon aléatoire
+pnpm run scrape           # récupère les montagnes russes
+pnpm run scrape:theme-parks # récupère les parcs d'attractions
+pnpm run scrape:random # récupère un échantillon aléatoire
 ```
 
 - Via l'API (exemple) :

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ce projet nécessite **Node.js 18** ou plus récent.
 
 ## Prérequis
 
-- Node 18+ et npm.
+- Node 18+ et pnpm.
 
 ---
 
@@ -27,20 +27,20 @@ Ce projet nécessite **Node.js 18** ou plus récent.
 
 1. Installer les dépendances
    ```bash
-   npm install
+   pnpm install
    ```
 2. Construire le projet
    ```bash
-   npm run build
+   pnpm run build
    ```
 3. Lancer l'API
    - Développement: recompilation et rechargement automatiques via `nodemon`.
      ```bash
-     npm run start:dev
+     pnpm run start:dev
      ```
    - Production: exécute le JavaScript compilé depuis `dist/`.
      ```bash
-     npm run start:prod
+     pnpm run start:prod
      ```
 
 ### Variables d'environnement
@@ -68,14 +68,14 @@ Cette commande utilise le runner de tests natif de Node pour valider les endpoin
 
 ## Scraping des données (installation locale)
 
-L'API fonctionne avec des fichiers JSON situés dans `src/db/`. Ces fichiers sont générés en scrappant RCDB. Plusieurs scripts npm sont fournis.
+L'API fonctionne avec des fichiers JSON situés dans `src/db/`. Ces fichiers sont générés en scrappant RCDB. Plusieurs scripts pnpm sont fournis.
 
-- `npm run scrape` - récupère les montagnes russes depuis RCDB. Options `--startId`/`--endId` ou `--startPage`/`--endPage`. Les données brutes sont enregistrées dans `src/db/coasters-raw.json` puis, si `--saveData` vaut `true`, dans `src/db/coasters.json`.
-- `npm run scrape:theme-parks` - récupère les informations des parcs et les sauvegarde dans `src/db/theme-parks.json`.
-- `npm run scrape:map-coaster-photos` - associe les URL d'images des montagnes russes déjà récupérées avec l'URL de base configurée.
-- `npm run scrape:random` - récupère un échantillon aléatoire de montagnes russes et le stocke dans `src/db/random-coasters.json`.
+- `pnpm run scrape` - récupère les montagnes russes depuis RCDB. Options `--startId`/`--endId` ou `--startPage`/`--endPage`. Les données brutes sont enregistrées dans `src/db/coasters-raw.json` puis, si `--saveData` vaut `true`, dans `src/db/coasters.json`.
+- `pnpm run scrape:theme-parks` - récupère les informations des parcs et les sauvegarde dans `src/db/theme-parks.json`.
+- `pnpm run scrape:map-coaster-photos` - associe les URL d'images des montagnes russes déjà récupérées avec l'URL de base configurée.
+- `pnpm run scrape:random` - récupère un échantillon aléatoire de montagnes russes et le stocke dans `src/db/random-coasters.json`.
 
-Ces scripts téléchargent les pages RCDB via `axios`, extraient les données avec `cheerio` et écrivent les fichiers JSON dans `src/db/`. Ils peuvent aussi être déclenchés via l'interface web qui communique avec un service démarrant les scripts npm et diffusant les logs en temps réel.
+Ces scripts téléchargent les pages RCDB via `axios`, extraient les données avec `cheerio` et écrivent les fichiers JSON dans `src/db/`. Ils peuvent aussi être déclenchés via l'interface web qui communique avec un service démarrant les scripts pnpm et diffusant les logs en temps réel.
 
 ### Routes de gestion des fichiers de scraping
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rm -rf dist && tsc && tsc-alias",
     "start:prod": "node dist/main.js",
     "start:dev": "nodemon",
-    "scrape": "ts-node -r tsconfig-paths/register ./src/scraping/main.ts && npm run scrape:map-coaster-photos",
+    "scrape": "ts-node -r tsconfig-paths/register ./src/scraping/main.ts && pnpm run scrape:map-coaster-photos",
     "scrape:theme-parks": "ts-node -r tsconfig-paths/register ./src/scraping/scrape-theme-parks",
     "scrape:map-coaster-photos": "ts-node -r tsconfig-paths/register ./src/scraping/map-coaster-photos.ts",
     "scrape:random": "ts-node -r tsconfig-paths/register ./src/scraping/scrape-random-coasters.ts",

--- a/src/lib/core/server.ts
+++ b/src/lib/core/server.ts
@@ -74,8 +74,8 @@ export default class Server {
       const expressRouter = Router();
       const controllerInstance: { [handleName: string]: Handler } = new ControllerClass();
 
-      // TODO: Refactor this code to make property injection more clear
-      // TODO: Define a service interface to be used as type to be injected
+      // Injecte les dépendances déclarées via les décorateurs.
+      // Chaque propriété typée reçoit l'instance correspondante du conteneur DI.
       injectedProperties.forEach(({ propertyKey, propertyType }) => {
         controllerInstance[propertyKey] = this._diContainer.getInjectable(propertyType);
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,10 @@ import {
   CookieController
 } from '@app/controllers';
 
+/**
+ * Point d'entrée principal de l'application.
+ * Initialise le serveur Express et enregistre les différents contrôleurs.
+ */
 class Application {
   _appServer: Server;
 

--- a/src/scraping/scrape-random-coasters.ts
+++ b/src/scraping/scrape-random-coasters.ts
@@ -23,6 +23,6 @@ function getRandomIds(amount: number, min: number, max: number): number[] {
 
   await db.writeDBFile(__RANDOM_COASTERS_DB_FILENAME__, coasters);
 
-  // If you need to map images to a static path, run:
-  // npm run scrape:map-coaster-photos
+  // Si vous devez mapper les images vers un chemin statique, lancez :
+  // pnpm run scrape:map-coaster-photos
 })();

--- a/src/services/scrape-service.ts
+++ b/src/services/scrape-service.ts
@@ -17,7 +17,7 @@ export interface ScrapeTask {
 
 @Service()
 /**
- * Runs the scraping npm scripts and streams their output through Socket.IO.
+ * Exécute les scripts de scraping via pnpm et diffuse leurs logs en temps réel avec Socket.IO.
  */
 export default class ScrapeService {
   private _currentProcess: ChildProcessWithoutNullStreams | null = null;
@@ -27,8 +27,8 @@ export default class ScrapeService {
   private _currentTaskId: number | null = null;
 
   /**
-   * Launch a scraping npm script and forward its output to connected clients.
-   * Only one task can run at a time. Returns the task information when started.
+   * Lance un script de scraping via pnpm et retransmet sa sortie aux clients connectés.
+   * Une seule tâche peut s'exécuter à la fois. Renvoie les informations de la tâche démarrée.
    */
   async start(script: string): Promise<ScrapeTask> {
     if (this._currentProcess) {
@@ -48,7 +48,7 @@ export default class ScrapeService {
     this._logCache = task.logs;
 
     return new Promise((resolve, reject) => {
-      const child = spawn('npm', ['run', script], { shell: true });
+      const child = spawn('pnpm', ['run', script], { shell: true });
       this._currentProcess = child;
 
       const send = (event: string, msg: string) => {

--- a/src/services/theme-park-service.ts
+++ b/src/services/theme-park-service.ts
@@ -6,7 +6,7 @@ import { PaginatedResponse } from '@app/models';
 
 @Service()
 /**
- * Service providing access to theme park information stored in JSON files.
+ * Service fournissant l'accès aux informations des parcs d'attractions stockées dans des fichiers JSON.
  */
 export default class ThemeParkService {
   private _dbJson: JsonDB;
@@ -29,12 +29,12 @@ export default class ThemeParkService {
   public async getThemeParkById(themeParkId: number): Promise<ThemePark | undefined> {
     const themeParks: ThemePark[] = await this._getThemeParksDb();
 
-    // Return the park with the matching id if it exists
+    // Retourne le parc correspondant à l'identifiant s'il existe
     return themeParks.find(({ id }: ThemePark) => id === themeParkId);
   }
 
   /**
-   * Search a theme park by name.
+   * Recherche un parc d'attractions par son nom.
    */
   public async searchThemeParks(searchTerm: string): Promise<ThemePark[]> {
     const themeParks: ThemePark[] = await this._getThemeParksDb();

--- a/static/index.html
+++ b/static/index.html
@@ -30,9 +30,9 @@
     <h2>Démarrage rapide</h2>
     <ol>
       <li>Clonez le projet : <code>git clone https://github.com/alexjuillardoff/ridexplorers_api</code></li>
-      <li>Installez les dépendances : <code>npm install</code></li>
-      <li>Compilez le code TypeScript : <code>npm run build</code></li>
-      <li>Lancez l'API en développement : <code>npm run start:dev</code></li>
+      <li>Installez les dépendances : <code>pnpm install</code></li>
+      <li>Compilez le code TypeScript : <code>pnpm run build</code></li>
+      <li>Lancez l'API en développement : <code>pnpm run start:dev</code></li>
     </ol>
     <p>La documentation interactive Swagger est accessible sur <code>/docs</code> une fois le serveur démarré.</p>
     <h2>Fonctionnalités principales</h2>


### PR DESCRIPTION
## Summary
- replace npm instructions with pnpm across documentation and static pages
- clarify dependency injection and service behavior with French comments
- spawn scraping tasks via pnpm and adjust scripts accordingly

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeeba3480083319bbd03f100de761f