### PR TITLE
[root] add blog feed management

### DIFF
--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -4,3 +4,4 @@ export const __PHOTOS_BY_COASTER_DB_FILENAME__: string = 'photos-by-coaster';
 export const __PROCESSED_COASTERS_PHOTOS_DB_FILENAME__: string = 'processed-coasters-photos';
 export const __THEME_PARKS_DB_FILENAME__: string = 'theme-parks';
 export const __RANDOM_COASTERS_DB_FILENAME__: string = 'random-coasters';
+export const __BLOG_FEEDS_DB_FILENAME__: string = 'blog-feeds';

--- a/src/controllers/blog-controller.ts
+++ b/src/controllers/blog-controller.ts
@@ -1,0 +1,37 @@
+import { BlogService } from '@app/services';
+import { Controller, Get, Inject, Post } from '@lib/decorators';
+import type { Request, Response } from 'express';
+
+@Controller('/api/blog')
+export default class BlogController {
+  @Inject() private _blogService: BlogService;
+
+  @Get('/feeds')
+  public async listFeeds(_: Request, res: Response): Promise<void> {
+    const feeds = await this._blogService.listFeeds();
+    res.status(200).json(feeds);
+  }
+
+  @Post('/feeds')
+  public async saveFeed(req: Request, res: Response): Promise<void> {
+    const { name, schema } = req.body;
+    if (!name || !schema) {
+      res.status(400).json({ error: 'name and schema required' });
+      return;
+    }
+    await this._blogService.saveFeed(name, schema);
+    res.status(200).json({ name, schema });
+  }
+
+  @Post('/feeds/:feed/items')
+  public async addItem(req: Request, res: Response): Promise<void> {
+    const { feed } = req.params;
+    const item = req.body;
+    try {
+      await this._blogService.addItem(feed, item);
+      res.status(200).json({ ok: true });
+    } catch (e: any) {
+      res.status(400).json({ error: e.message });
+    }
+  }
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -3,3 +3,4 @@ export { default as IndexController } from './index-controller';
 export { default as ThemeParksController } from './theme-parks-controller';
 export { default as ScrapeController } from './scrape-controller';
 export { default as CookieController } from './cookie-controller';
+export { default as BlogController } from './blog-controller';

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,8 @@ import {
   IndexController,
   ThemeParksController,
   ScrapeController,
-  CookieController
+  CookieController,
+  BlogController
 } from '@app/controllers';
 
 /**
@@ -23,7 +24,8 @@ class Application {
       RollerCoastersController,
       ThemeParksController,
       ScrapeController,
-      CookieController
+      CookieController,
+      BlogController
     ]);
 
   }

--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -1,0 +1,40 @@
+import { __BLOG_FEEDS_DB_FILENAME__ } from '@app/constants';
+import JsonDB from '@app/db';
+import type { BlogFeed, BlogFeeds } from '@app/types';
+import { Service } from '@lib/decorators';
+
+@Service()
+export default class BlogService {
+  private _db: JsonDB;
+
+  constructor() {
+    this._db = JsonDB.getInstance();
+    this._db.createDBFile(__BLOG_FEEDS_DB_FILENAME__, {});
+  }
+
+  private async _getFeeds(): Promise<BlogFeeds> {
+    return await this._db.readDBFile<BlogFeeds>(__BLOG_FEEDS_DB_FILENAME__);
+  }
+
+  public async listFeeds(): Promise<{ name: string; schema: any }[]> {
+    const feeds = await this._getFeeds();
+    return Object.entries(feeds).map(([name, { schema }]) => ({ name, schema }));
+  }
+
+  public async saveFeed(name: string, schema: any): Promise<void> {
+    const feeds = await this._getFeeds();
+    const items = feeds[name]?.items ?? [];
+    feeds[name] = { schema, items } as BlogFeed;
+    await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
+  }
+
+  public async addItem(feedName: string, item: any): Promise<void> {
+    const feeds = await this._getFeeds();
+    const feed = feeds[feedName];
+    if (!feed) {
+      throw new Error(`Feed ${feedName} not found`);
+    }
+    feed.items.push(item);
+    await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
 export { default as RollerCoasterService } from './roller-coaster-service';
 export { default as ThemeParkService } from './theme-park-service';
 export { default as ScrapeService } from './scrape-service';
+export { default as BlogService } from './blog-service';

--- a/src/types/blog-feed.ts
+++ b/src/types/blog-feed.ts
@@ -1,0 +1,12 @@
+export interface BlogFeedItem {
+  [key: string]: any;
+}
+
+export default interface BlogFeed {
+  schema: any;
+  items: BlogFeedItem[];
+}
+
+export interface BlogFeeds {
+  [name: string]: BlogFeed;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export { default as RcdbPicture } from './rcdb-picture';
 export { default as Picture } from './picture';
 export { default as ThemePark, SocialMedia } from './theme-park';
 export { default as ParkCoaster } from './park-coaster';
+export { default as BlogFeed, BlogFeedItem, BlogFeeds } from './blog-feed';

--- a/static/blog.js
+++ b/static/blog.js
@@ -1,0 +1,64 @@
+(function(){
+  const schemaContainer = document.getElementById('schema-editor');
+  const itemContainer = document.getElementById('item-editor');
+  const feedNameInput = document.getElementById('feed-name');
+  const feedSelect = document.getElementById('feed-select');
+  const saveFeedBtn = document.getElementById('save-feed');
+  const addItemBtn = document.getElementById('add-item');
+
+  const schemaEditor = new JSONEditor(schemaContainer, { mode: 'code' });
+  let itemEditor = new JSONEditor(itemContainer, { mode: 'code' });
+
+  function authHeader() {
+    const token = localStorage.getItem('authToken');
+    return token ? { Authorization: 'Basic ' + token } : {};
+  }
+
+  function loadFeeds() {
+    fetch('/api/blog/feeds', { headers: authHeader() })
+      .then(r => r.json())
+      .then(feeds => {
+        feedSelect.innerHTML = '<option value="">-- Choisir un flux --</option>';
+        feeds.forEach(f => {
+          const opt = document.createElement('option');
+          opt.value = f.name;
+          opt.textContent = f.name;
+          opt.dataset.schema = JSON.stringify(f.schema || {});
+          feedSelect.appendChild(opt);
+        });
+      });
+  }
+
+  feedSelect.addEventListener('change', () => {
+    const selected = feedSelect.options[feedSelect.selectedIndex];
+    const schema = selected.dataset.schema ? JSON.parse(selected.dataset.schema) : {};
+    feedNameInput.value = selected.value;
+    schemaEditor.set(schema);
+    itemEditor.destroy();
+    itemEditor = new JSONEditor(itemContainer, { mode: 'code', schema });
+    itemEditor.set({});
+  });
+
+  saveFeedBtn.addEventListener('click', () => {
+    const name = feedNameInput.value;
+    const schema = schemaEditor.get();
+    fetch('/api/blog/feeds', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeader() },
+      body: JSON.stringify({ name, schema })
+    }).then(() => loadFeeds());
+  });
+
+  addItemBtn.addEventListener('click', () => {
+    const feed = feedSelect.value || feedNameInput.value;
+    if (!feed) return;
+    const item = itemEditor.get();
+    fetch(`/api/blog/feeds/${encodeURIComponent(feed)}/items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeader() },
+      body: JSON.stringify(item)
+    });
+  });
+
+  loadFeeds();
+})();

--- a/static/blog/index.html
+++ b/static/blog/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gestion du blog</title>
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsoneditor@latest/dist/jsoneditor.min.css" />
+</head>
+<body>
+  <div class="navbar">
+    <span class="api-name">RIDEXPLORERS API</span>
+    <div class="navbar-right">
+      <span class="auth-status" id="auth-status"></span>
+      <form id="login-form">
+        <input id="username" placeholder="Username" />
+        <input type="password" id="password" placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+      <button id="logout-button" style="display:none;">Logout</button>
+    </div>
+  </div>
+  <nav class="nav-links">
+    <a href="/">Accueil</a>
+    <a href="/docs" target="_blank">Swagger Docs</a>
+    <a href="/files.html">Gestionnaire de fichiers</a>
+  </nav>
+  <div class="container">
+    <h1>Gestion du blog</h1>
+    <section>
+      <h2>Création ou édition de flux</h2>
+      <input id="feed-name" placeholder="Nom du flux" />
+      <div id="schema-editor" style="height: 300px;"></div>
+      <button id="save-feed">Enregistrer le flux</button>
+    </section>
+    <section>
+      <h2>Ajouter une news</h2>
+      <select id="feed-select"></select>
+      <div id="item-editor" style="height: 300px;"></div>
+      <button id="add-item">Ajouter</button>
+    </section>
+  </div>
+  <div id="cookie-banner" class="cookie-banner">
+    Ce site utilise des cookies techniques uniquement. <button id="accept-cookies">OK</button>
+  </div>
+  <script src="/login.js"></script>
+  <script src="/cookies.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jsoneditor@latest/dist/jsoneditor.min.js"></script>
+  <script src="/blog.js"></script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -23,6 +23,7 @@
     <a href="/">Accueil</a>
     <a href="/docs" target="_blank">Swagger Docs</a>
     <a href="/files.html">Gestionnaire de fichiers</a>
+    <a href="/blog">Blog</a>
   </nav>
   <div class="container">
     <h1>Bienvenue sur RIDEXPLORERS API</h1>


### PR DESCRIPTION
## Summary
- add constants, types and service for blog feed persistence
- expose blog feed API with JSON editing endpoints
- create static blog management page and link from home

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aeee72d01883319eabe2703dd39b80