### PR TITLE
[express-server-ts] Add blog feed retrieval endpoint

### DIFF
--- a/src/controllers/blog-controller.ts
+++ b/src/controllers/blog-controller.ts
@@ -23,6 +23,17 @@ export default class BlogController {
     res.status(200).json({ name, schema });
   }
 
+  @Get('/feeds/:feed')
+  public async getFeed(req: Request, res: Response): Promise<void> {
+    const { feed } = req.params;
+    try {
+      const blogFeed = await this._blogService.getFeed(feed);
+      res.status(200).json(blogFeed);
+    } catch (e: any) {
+      res.status(404).json({ error: e.message });
+    }
+  }
+
   @Post('/feeds/:feed/items')
   public async addItem(req: Request, res: Response): Promise<void> {
     const { feed } = req.params;

--- a/src/services/blog-service.test.ts
+++ b/src/services/blog-service.test.ts
@@ -1,0 +1,37 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import BlogService from './blog-service';
+
+const dbFile = path.join(process.cwd(), 'src', 'db', 'blog-feeds.json');
+
+beforeEach(async () => {
+  try {
+    await fs.rm(dbFile);
+  } catch {
+    // ignore if file does not exist
+  }
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(dbFile);
+  } catch {
+    // ignore
+  }
+});
+
+test('getFeed returns saved feed with items', async () => {
+  const service = new BlogService();
+  await service.saveFeed('test', { title: 'string' });
+  await service.addItem('test', { title: 'hello' });
+  const feed = await service.getFeed('test');
+  assert.equal(feed.items.length, 1);
+  assert.equal(feed.items[0].title, 'hello');
+});
+
+test('getFeed throws error when feed not found', async () => {
+  const service = new BlogService();
+  await assert.rejects(() => service.getFeed('unknown'));
+});

--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -28,6 +28,15 @@ export default class BlogService {
     await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
   }
 
+  public async getFeed(feedName: string): Promise<BlogFeed> {
+    const feeds = await this._getFeeds();
+    const feed = feeds[feedName];
+    if (!feed) {
+      throw new Error(`Feed ${feedName} not found`);
+    }
+    return feed;
+  }
+
   public async addItem(feedName: string, item: any): Promise<void> {
     const feeds = await this._getFeeds();
     const feed = feeds[feedName];


### PR DESCRIPTION
## Summary
- add ability to fetch individual blog feeds
- support feed retrieval in BlogService
- cover BlogService feed operations with tests

## Testing
- `pnpm test src/services/blog-service.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68aef1e0e4608331bdad3a35b03c3e4f