### PR TITLE
[express-server-ts] add blog feed service

### DIFF
--- a/src/controllers/blog-controller.ts
+++ b/src/controllers/blog-controller.ts
@@ -13,22 +13,22 @@ export default class BlogController {
   }
 
   @Post('/feeds')
-  public async saveFeed(req: Request, res: Response): Promise<void> {
+  public async createFeed(req: Request, res: Response): Promise<void> {
     const { name, schema } = req.body;
     if (!name || !schema) {
       res.status(400).json({ error: 'name and schema required' });
       return;
     }
-    await this._blogService.saveFeed(name, schema);
+    await this._blogService.createFeed(name, schema);
     res.status(200).json({ name, schema });
   }
 
   @Get('/feeds/:feed')
-  public async getFeed(req: Request, res: Response): Promise<void> {
+  public async getFeedItems(req: Request, res: Response): Promise<void> {
     const { feed } = req.params;
     try {
-      const blogFeed = await this._blogService.getFeed(feed);
-      res.status(200).json(blogFeed);
+      const items = await this._blogService.getFeedItems(feed);
+      res.status(200).json(items);
     } catch (e: any) {
       res.status(404).json({ error: e.message });
     }

--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -1,6 +1,5 @@
 import { __BLOG_FEEDS_DB_FILENAME__ } from '@app/constants';
 import JsonDB from '@app/db';
-import type { BlogFeed, BlogFeeds } from '@app/types';
 import { Service } from '@lib/decorators';
 
 @Service()
@@ -12,38 +11,32 @@ export default class BlogService {
     this._db.createDBFile(__BLOG_FEEDS_DB_FILENAME__, {});
   }
 
-  private async _getFeeds(): Promise<BlogFeeds> {
-    return await this._db.readDBFile<BlogFeeds>(__BLOG_FEEDS_DB_FILENAME__);
+  public async createFeed(name: string, schema: any): Promise<void> {
+    await this._db.createDBFile(`blog-${name}`, []);
+    await this._db.pushKeyObjectToDB(__BLOG_FEEDS_DB_FILENAME__, {
+      [name]: { id: name, schema },
+    });
+  }
+
+  public async addItem(feed: string, item: any): Promise<void> {
+    const items = await this._db.readDBFile<any[]>(`blog-${feed}`);
+    items.push(item);
+    await this._db.writeDBFile(`blog-${feed}`, items);
+  }
+
+  public async getFeedItems(feed: string): Promise<any[]> {
+    try {
+      return await this._db.readDBFile<any[]>(`blog-${feed}`);
+    } catch {
+      throw new Error(`Feed ${feed} not found`);
+    }
   }
 
   public async listFeeds(): Promise<{ name: string; schema: any }[]> {
-    const feeds = await this._getFeeds();
-    return Object.entries(feeds).map(([name, { schema }]) => ({ name, schema }));
-  }
-
-  public async saveFeed(name: string, schema: any): Promise<void> {
-    const feeds = await this._getFeeds();
-    const items = feeds[name]?.items ?? [];
-    feeds[name] = { schema, items } as BlogFeed;
-    await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
-  }
-
-  public async getFeed(feedName: string): Promise<BlogFeed> {
-    const feeds = await this._getFeeds();
-    const feed = feeds[feedName];
-    if (!feed) {
-      throw new Error(`Feed ${feedName} not found`);
-    }
-    return feed;
-  }
-
-  public async addItem(feedName: string, item: any): Promise<void> {
-    const feeds = await this._getFeeds();
-    const feed = feeds[feedName];
-    if (!feed) {
-      throw new Error(`Feed ${feedName} not found`);
-    }
-    feed.items.push(item);
-    await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
+    const feeds = await this._db.readDBFile<Record<string, { id: string; schema: any }>>(
+      __BLOG_FEEDS_DB_FILENAME__
+    );
+    return Object.keys(feeds).map((name) => ({ name, schema: feeds[name].schema }));
   }
 }
+


### PR DESCRIPTION
## Summary
- implement blog feed service with feed creation, item storage, and listing
- update blog controller to expose feed management endpoints
- add unit tests for blog feed service

## Testing
- `pnpm test`
- `node --test --require reflect-metadata --require tsconfig-paths/register --require ts-node/register src/services/blog-service.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aef2a6da688331b1c789b2c00ec42e