### PR TITLE
[express-server-ts] secure blog routes and validate posts

### DIFF
--- a/src/lib/core/server.test.ts
+++ b/src/lib/core/server.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Server from './server';
+
+test('does not apply auth middleware without credentials', () => {
+  process.env.NODE_ENV = 'test';
+  delete process.env.AUTH_USER;
+  delete process.env.AUTH_PASSWORD;
+  const server = new Server();
+  const hasAuth = server.app._router.stack.some(
+    (layer: any) => layer.name === 'authenticate' && layer.regexp?.test('/api/blog')
+  );
+  assert.equal(hasAuth, false);
+});
+
+test('applies auth middleware to /api/blog when credentials provided', () => {
+  process.env.NODE_ENV = 'test';
+  process.env.AUTH_USER = 'user';
+  process.env.AUTH_PASSWORD = 'pass';
+  const server = new Server();
+  const hasAuth = server.app._router.stack.some(
+    (layer: any) => layer.name === 'authenticate' && layer.regexp?.test('/api/blog')
+  );
+  assert.equal(hasAuth, true);
+});

--- a/src/services/blog-service.test.ts
+++ b/src/services/blog-service.test.ts
@@ -43,3 +43,10 @@ test('getFeedItems throws error when feed not found', async () => {
   await assert.rejects(() => service.getFeedItems('unknown'));
 });
 
+test('addItem validates objects against schema', async () => {
+  const service = new BlogService();
+  await service.createFeed('test', { title: 'string' });
+  await assert.rejects(() => service.addItem('test', { id: 1 }), /Invalid item/);
+  await assert.rejects(() => service.addItem('test', { title: 1 }), /Invalid item/);
+});
+


### PR DESCRIPTION
## Summary
- apply auth middleware to blog routes when credentials are set
- validate blog items against feed schema before saving
- add tests for blog auth middleware and schema validation

## Testing
- `pnpm test` (no tests found)
- `node --test --require reflect-metadata --require tsconfig-paths/register --require ts-node/register src/services/blog-service.test.ts src/lib/core/server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68aef38f777c8331bef09d0bf58f9fe7