### PR TITLE
[ridexplorers_api] Add feed management UI and API

### DIFF
--- a/src/controllers/blog-controller.ts
+++ b/src/controllers/blog-controller.ts
@@ -1,5 +1,5 @@
 import { BlogService } from '@app/services';
-import { Controller, Get, Inject, Post } from '@lib/decorators';
+import { Controller, Delete, Get, Inject, Post, Put } from '@lib/decorators';
 import type { Request, Response } from 'express';
 
 @Controller('/api/blog')
@@ -14,33 +14,64 @@ export default class BlogController {
 
   @Post('/feeds')
   public async createFeed(req: Request, res: Response): Promise<void> {
-    const { name, schema } = req.body;
-    if (!name || !schema) {
-      res.status(400).json({ error: 'name and schema required' });
+    const { name } = req.body;
+    if (!name) {
+      res.status(400).json({ error: 'name required' });
       return;
     }
-    await this._blogService.createFeed(name, schema);
-    res.status(200).json({ name, schema });
+    try {
+      const feed = await this._blogService.createFeed(name);
+      res.status(200).json(feed);
+    } catch (e: any) {
+      res.status(400).json({ error: e.message });
+    }
   }
 
-  @Get('/feeds/:feed')
-  public async getFeedItems(req: Request, res: Response): Promise<void> {
-    const { feed } = req.params;
+  @Get('/feeds/:slug')
+  public async getFeed(req: Request, res: Response): Promise<void> {
+    const { slug } = req.params;
     try {
-      const items = await this._blogService.getFeedItems(feed);
-      res.status(200).json(items);
+      const content = await this._blogService.getFeed(slug);
+      res.status(200).json(content);
     } catch (e: any) {
       res.status(404).json({ error: e.message });
     }
   }
 
-  @Post('/feeds/:feed/items')
-  public async addItem(req: Request, res: Response): Promise<void> {
-    const { feed } = req.params;
-    const item = req.body;
+  @Put('/feeds/:slug')
+  public async updateFeed(req: Request, res: Response): Promise<void> {
+    const { slug } = req.params;
+    const content = req.body;
     try {
-      await this._blogService.addItem(feed, item);
+      await this._blogService.updateFeed(slug, content);
       res.status(200).json({ ok: true });
+    } catch (e: any) {
+      res.status(400).json({ error: e.message });
+    }
+  }
+
+  @Delete('/feeds/:slug')
+  public async deleteFeed(req: Request, res: Response): Promise<void> {
+    const { slug } = req.params;
+    try {
+      await this._blogService.deleteFeed(slug);
+      res.status(200).json({ ok: true });
+    } catch (e: any) {
+      res.status(404).json({ error: e.message });
+    }
+  }
+
+  @Post('/feeds/:slug/rename')
+  public async renameFeed(req: Request, res: Response): Promise<void> {
+    const { slug } = req.params;
+    const { name } = req.body;
+    if (!name) {
+      res.status(400).json({ error: 'name required' });
+      return;
+    }
+    try {
+      const feed = await this._blogService.renameFeed(slug, name);
+      res.status(200).json(feed);
     } catch (e: any) {
       res.status(400).json({ error: e.message });
     }

--- a/src/controllers/blog-public-controller.ts
+++ b/src/controllers/blog-public-controller.ts
@@ -1,0 +1,19 @@
+import { BlogService } from '@app/services';
+import { Controller, Get, Inject } from '@lib/decorators';
+import type { Request, Response } from 'express';
+
+@Controller('/blog')
+export default class BlogPublicController {
+  @Inject() private _blogService: BlogService;
+
+  @Get('/:slug')
+  public async getFeed(req: Request, res: Response): Promise<void> {
+    const { slug } = req.params;
+    try {
+      const content = await this._blogService.getFeed(slug);
+      res.status(200).json(content);
+    } catch (e: any) {
+      res.status(404).json({ error: e.message });
+    }
+  }
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -4,3 +4,4 @@ export { default as ThemeParksController } from './theme-parks-controller';
 export { default as ScrapeController } from './scrape-controller';
 export { default as CookieController } from './cookie-controller';
 export { default as BlogController } from './blog-controller';
+export { default as BlogPublicController } from './blog-public-controller';

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,8 @@ import {
   ThemeParksController,
   ScrapeController,
   CookieController,
-  BlogController
+  BlogController,
+  BlogPublicController
 } from '@app/controllers';
 
 /**
@@ -25,7 +26,8 @@ class Application {
       ThemeParksController,
       ScrapeController,
       CookieController,
-      BlogController
+      BlogController,
+      BlogPublicController
     ]);
 
   }

--- a/src/services/blog-service.ts
+++ b/src/services/blog-service.ts
@@ -1,56 +1,88 @@
 import { __BLOG_FEEDS_DB_FILENAME__ } from '@app/constants';
 import JsonDB from '@app/db';
+import { slugify } from '@app/utils';
 import { Service } from '@lib/decorators';
+import { promises as fs } from 'fs';
+import path from 'path';
 
 @Service()
 export default class BlogService {
   private _db: JsonDB;
+  private _dbPath: string;
 
   constructor() {
     this._db = JsonDB.getInstance();
     this._db.createDBFile(__BLOG_FEEDS_DB_FILENAME__, {});
+    this._dbPath = path.join(process.cwd(), 'src', 'db');
   }
 
-  public async createFeed(name: string, schema: any): Promise<void> {
-    await this._db.createDBFile(`blog-${name}`, []);
+  public async listFeeds(): Promise<{ name: string; slug: string }[]> {
+    const feeds = await this._db.readDBFile<Record<string, { id: string; name: string }>>(
+      __BLOG_FEEDS_DB_FILENAME__
+    );
+    return Object.keys(feeds).map((slug) => ({ slug, name: feeds[slug].name }));
+  }
+
+  public async createFeed(name: string): Promise<{ name: string; slug: string }> {
+    const slug = slugify(name);
+    const feeds = await this._db.readDBFile<Record<string, { id: string; name: string }>>(
+      __BLOG_FEEDS_DB_FILENAME__
+    );
+    if (feeds[slug]) {
+      throw new Error('Feed already exists');
+    }
+    await this._db.createDBFile(`blog-${slug}`, {});
     await this._db.pushKeyObjectToDB(__BLOG_FEEDS_DB_FILENAME__, {
-      [name]: { id: name, schema },
+      [slug]: { id: slug, name },
     });
+    return { name, slug };
   }
 
-  public async addItem(feed: string, item: any): Promise<void> {
-    const feeds = await this._db.readDBFile<Record<string, { id: string; schema: any }>>(
-      __BLOG_FEEDS_DB_FILENAME__
-    );
-    const feedInfo = feeds[feed];
-    if (!feedInfo) {
-      throw new Error(`Feed ${feed} not found`);
-    }
-    const schema = feedInfo.schema as Record<string, string>;
-    const parsedItem = typeof item === 'string' ? JSON.parse(item) : item;
-    for (const [key, type] of Object.entries(schema)) {
-      if (!(key in parsedItem) || typeof parsedItem[key] !== type) {
-        throw new Error('Invalid item');
-      }
-    }
-    const items = await this._db.readDBFile<any[]>(`blog-${feed}`);
-    items.push(parsedItem);
-    await this._db.writeDBFile(`blog-${feed}`, items);
-  }
-
-  public async getFeedItems(feed: string): Promise<any[]> {
+  public async getFeed(slug: string): Promise<any> {
     try {
-      return await this._db.readDBFile<any[]>(`blog-${feed}`);
+      return await this._db.readDBFile<any>(`blog-${slug}`);
     } catch {
-      throw new Error(`Feed ${feed} not found`);
+      throw new Error(`Feed ${slug} not found`);
     }
   }
 
-  public async listFeeds(): Promise<{ name: string; schema: any }[]> {
-    const feeds = await this._db.readDBFile<Record<string, { id: string; schema: any }>>(
+  public async updateFeed(slug: string, content: any): Promise<void> {
+    await this._db.writeDBFile(`blog-${slug}`, content);
+  }
+
+  public async deleteFeed(slug: string): Promise<void> {
+    const feeds = await this._db.readDBFile<Record<string, { id: string; name: string }>>(
       __BLOG_FEEDS_DB_FILENAME__
     );
-    return Object.keys(feeds).map((name) => ({ name, schema: feeds[name].schema }));
+    if (!feeds[slug]) {
+      throw new Error(`Feed ${slug} not found`);
+    }
+    delete feeds[slug];
+    await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
+    await fs.rm(path.join(this._dbPath, `blog-${slug}.json`), { force: true });
+  }
+
+  public async renameFeed(
+    slug: string,
+    newName: string
+  ): Promise<{ name: string; slug: string }> {
+    const feeds = await this._db.readDBFile<Record<string, { id: string; name: string }>>(
+      __BLOG_FEEDS_DB_FILENAME__
+    );
+    if (!feeds[slug]) {
+      throw new Error(`Feed ${slug} not found`);
+    }
+    const newSlug = slugify(newName);
+    if (feeds[newSlug]) {
+      throw new Error('Feed already exists');
+    }
+    await fs.rename(
+      path.join(this._dbPath, `blog-${slug}.json`),
+      path.join(this._dbPath, `blog-${newSlug}.json`)
+    );
+    delete feeds[slug];
+    feeds[newSlug] = { id: newSlug, name: newName };
+    await this._db.writeDBFile(__BLOG_FEEDS_DB_FILENAME__, feeds);
+    return { name: newName, slug: newSlug };
   }
 }
-

--- a/src/types/blog-feed.ts
+++ b/src/types/blog-feed.ts
@@ -1,12 +1,8 @@
-export interface BlogFeedItem {
-  [key: string]: any;
-}
-
 export default interface BlogFeed {
-  schema: any;
-  items: BlogFeedItem[];
+  name: string;
+  slug: string;
 }
 
 export interface BlogFeeds {
-  [name: string]: BlogFeed;
+  [slug: string]: { id: string; name: string };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,4 +4,4 @@ export { default as RcdbPicture } from './rcdb-picture';
 export { default as Picture } from './picture';
 export { default as ThemePark, SocialMedia } from './theme-park';
 export { default as ParkCoaster } from './park-coaster';
-export { default as BlogFeed, BlogFeedItem, BlogFeeds } from './blog-feed';
+export { default as BlogFeed, BlogFeeds } from './blog-feed';

--- a/static/blog/index.html
+++ b/static/blog/index.html
@@ -25,20 +25,18 @@
     <a href="/docs" target="_blank">Swagger Docs</a>
     <a href="/files.html">Gestionnaire de fichiers</a>
   </nav>
-  <div class="container">
-    <h1>Gestion du blog</h1>
-    <section>
-      <h2>Création ou édition de flux</h2>
-      <input id="feed-name" placeholder="Nom du flux" />
-      <div id="schema-editor" style="height: 300px;"></div>
-      <button id="save-feed">Enregistrer le flux</button>
-    </section>
-    <section>
-      <h2>Ajouter une news</h2>
-      <select id="feed-select"></select>
-      <div id="item-editor" style="height: 300px;"></div>
-      <button id="add-item">Ajouter</button>
-    </section>
+  <div class="container blog-manager">
+    <div class="feeds-column">
+      <div class="feeds-header">
+        <button id="create-feed">Créer un flux</button>
+      </div>
+      <ul id="feeds-list"></ul>
+    </div>
+    <div class="editor-column">
+      <h2 id="editor-title"></h2>
+      <div id="feed-editor" style="height: 500px;"></div>
+      <button id="save-feed" style="display:none;">Enregistrer</button>
+    </div>
   </div>
   <div id="cookie-banner" class="cookie-banner">
     Ce site utilise des cookies techniques uniquement. <button id="accept-cookies">OK</button>

--- a/static/style.css
+++ b/static/style.css
@@ -176,3 +176,47 @@ ul#files li {
   font-weight: bold;
 }
 
+.blog-manager {
+  display: flex;
+  gap: 1rem;
+}
+
+.feeds-column {
+  width: 200px;
+  border-right: 1px solid #ddd;
+  padding-right: 1rem;
+}
+
+#feeds-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.feed-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.feed-name {
+  cursor: pointer;
+}
+
+.feed-name:hover {
+  text-decoration: underline;
+}
+
+.feed-actions button {
+  margin-left: 0.25rem;
+}
+
+.editor-column {
+  flex: 1;
+  padding-left: 1rem;
+}
+
+.feeds-header {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- implement sidebar feed manager with create, rename, delete and view actions
- add backend endpoints and public slug route for feeds
- support slug-based feed storage with tests

## Testing
- `pnpm test` *(no tests detected)*
- `node --require reflect-metadata --require tsconfig-paths/register --require ts-node/register --test src/services/blog-service.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af6e861ba88331b0a5983e6317d21e