### PR TITLE
[express-server-ts] Adjust feed and editor column widths

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -196,7 +196,7 @@ ul#files li {
 }
 
 .feeds-column {
-  flex: 0 0 25%;
+  flex: 0 0 35%;
   border-right: 1px solid #ddd;
   padding-right: 1rem;
 }
@@ -238,7 +238,7 @@ ul#files li {
 }
 
 .editor-column {
-  flex: 0 0 75%;
+  flex: 0 0 65%;
   padding-left: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- widen feeds column to 35%
- narrow editor column to 65%

## Testing
- `pnpm test`
- Served `static` via `http-server` and reloaded `style.css`


------
https://chatgpt.com/codex/tasks/task_e_68af7a50ccec833181168b9f4e6eec95